### PR TITLE
Add staggered-grid Rayleigh-Bénard test

### DIFF
--- a/boussinesq_staggered.py
+++ b/boussinesq_staggered.py
@@ -158,26 +158,22 @@ def test_basic_staggered_operations():
         ax = axes[1, 1]
         ax.axis('off')
 
-        summary_text = f"""
-        STAGGERED GRID TEST RESULTS
-
-        Grid Size: {grid.nx} × {grid.nz}
-        Domain: {grid.Lx} × {grid.Lz}
-
-        Field Dimensions:
-        • Temperature: {T.shape}
-        • U-velocity: {u.shape}  
-        • W-velocity: {w.shape}
-
-        Operator Tests:
-        • Divergence: ✅
-        • Gradient: ✅
-        • Laplacian: ✅
-        • Interpolation: ✅
-
-        Max Divergence: {np.max(np.abs(div_u)):.2e}
-        (Should be ~0 for zero velocity)
-        """
+        summary_text = (
+            "STAGGERED GRID TEST RESULTS\n\n"
+            f"Grid Size: {grid.nx} × {grid.nz}\n"
+            f"Domain: {grid.Lx} × {grid.Lz}\n\n"
+            "Field Dimensions:\n"
+            f"- Temperature: {T.shape}\n"
+            f"- U-velocity: {u.shape}\n"
+            f"- W-velocity: {w.shape}\n\n"
+            "Operator Tests:\n"
+            "- Divergence: OK\n"
+            "- Gradient: OK\n"
+            "- Laplacian: OK\n"
+            "- Interpolation: OK\n\n"
+            f"Max Divergence: {np.max(np.abs(div_u)):.2e}\n"
+            "(Should be ~0 for zero velocity)"
+        )
 
         ax.text(0.1, 0.5, summary_text, fontsize=10, verticalalignment='center',
                 family='monospace')
@@ -197,20 +193,18 @@ def test_basic_staggered_operations():
     return True
 
 
-def test_simple_rb_collocated_fixed():
-    """
-    Fixed version with proper pressure projection and stronger perturbations
-    """
+def test_simple_rb_staggered_fixed():
+    """Rayleigh-Bénard test using a staggered grid with pressure projection."""
     print("\n" + "=" * 60)
-    print("FIXED R-B TEST (COLLOCATED GRID)")
+    print("FIXED R-B TEST (STAGGERED GRID)")
     print("=" * 60)
 
-    # Small collocated grid
-    grid = Grid2D(nx=16, nz=8, Lx=2.0, Lz=1.0, staggered=False)
+    # Small staggered grid
+    grid = Grid2D(nx=16, nz=8, Lx=2.0, Lz=1.0, staggered=True)
     operators = FluidOperators(grid)
 
-    # Physical parameters for moderate Ra
-    Ra_target = 5000  # Higher Ra for clearer convection
+    # Physical parameters
+    Ra_target = 5000
     L = grid.Lz
     g = 9.81
     alpha = 1e-3
@@ -221,151 +215,131 @@ def test_simple_rb_collocated_fixed():
     print(f"ν = κ = {nu:.2e}")
     print(f"Expected: Strong convection (Nu >> 1)")
 
-    # Create initial fields
-    u = np.zeros((grid.nz + 1, grid.nx + 1))
-    w = np.zeros((grid.nz + 1, grid.nx + 1))
-    T = np.zeros((grid.nz + 1, grid.nx + 1))
+    # Create staggered fields
+    u = grid.create_field('u_velocity')
+    w = grid.create_field('w_velocity')
+    T = grid.create_field('pressure')
 
-    # Initialize temperature with linear profile + STRONGER perturbation
+    # Initialize temperature with linear profile + perturbation
     x_p, z_p = grid.get_pressure_grid()
     T_hot, T_cold = 0.5, -0.5
 
     for j in range(grid.nz + 1):
-        # Linear profile
         T_linear = T_cold + (T_hot - T_cold) * (1 - z_p[j] / grid.Lz)
-        T[j, :] = T_linear
-
-        # Add STRONGER perturbation to trigger convection
         for i in range(grid.nx + 1):
             pert = 0.1 * np.sin(np.pi * x_p[i] / grid.Lx) * np.sin(np.pi * z_p[j] / grid.Lz)
-            T[j, i] += pert
+            T[j, i] = T_linear + pert
 
     # Apply boundary conditions
     def apply_bc(u, w, T):
-        # No-slip boundaries
-        u[0, :] = u[-1, :] = u[:, 0] = u[:, -1] = 0
-        w[0, :] = w[-1, :] = w[:, 0] = w[:, -1] = 0
+        u[0, :] = u[-1, :] = 0
+        u[:, 0] = u[:, -1] = 0
+        w[0, :] = w[-1, :] = 0
+        w[:, 0] = w[:, -1] = 0
 
-        # Temperature boundaries
-        T[0, :] = T_hot  # Hot bottom
-        T[-1, :] = T_cold  # Cold top
-        T[:, 0] = T[:, 1]  # Adiabatic sides
+        T[0, :] = T_hot
+        T[-1, :] = T_cold
+        T[:, 0] = T[:, 1]
         T[:, -1] = T[:, -2]
 
     apply_bc(u, w, T)
 
-    # Compute initial Nusselt number
     def compute_Nu(T):
         dT_dz_bottom = (T[1, :] - T[0, :]) / grid.dz
         avg_gradient = np.mean(dT_dz_bottom)
-        Nu = -L * avg_gradient / (T_hot - T_cold)
-        return Nu
+        return -L * avg_gradient / (T_hot - T_cold)
 
-    # Simple Poisson solver for pressure projection
     def solve_poisson_simple(rhs, max_iter=200):
         phi = np.zeros_like(rhs)
-        rhs_work = rhs - np.mean(rhs)  # Compatibility condition
-
+        rhs_work = rhs - np.mean(rhs)
         for it in range(max_iter):
             phi_old = phi.copy()
-
-            # Gauss-Seidel iteration
             for j in range(1, phi.shape[0] - 1):
                 for i in range(1, phi.shape[1] - 1):
-                    phi[j, i] = 0.25 * (phi[j + 1, i] + phi[j - 1, i] +
-                                        phi[j, i + 1] + phi[j, i - 1] -
-                                        grid.dx ** 2 * rhs_work[j, i])
-
-            # Neumann BC
+                    phi[j, i] = 0.25 * (
+                        phi[j + 1, i] + phi[j - 1, i] +
+                        phi[j, i + 1] + phi[j, i - 1] -
+                        grid.dx ** 2 * rhs_work[j, i]
+                    )
             phi[0, :] = phi[1, :]
             phi[-1, :] = phi[-2, :]
             phi[:, 0] = phi[:, 1]
             phi[:, -1] = phi[:, -2]
-
             phi -= np.mean(phi)
-
             if np.max(np.abs(phi - phi_old)) < 1e-6:
                 break
-
         return phi
 
     Nu_initial = compute_Nu(T)
     print(f"Initial Nu = {Nu_initial:.4f}")
-    print(f"Initial max perturbation: {np.max(np.abs(T - np.mean(T))):.4f}")
 
-    # Time stepping with pressure projection
-    dt = 5e-5  # Smaller time step
-    n_steps = 1000  # More steps
-
+    dt = 5e-5
+    n_steps = 1000
     print(f"Running {n_steps} time steps with dt = {dt:.1e}...")
 
     Nu_history = [Nu_initial]
     max_vel_history = []
 
     for step in range(n_steps):
-        # Buoyancy term (this should drive convection!)
         T_ref = (T_hot + T_cold) / 2
-        buoyancy = g * alpha * (T - T_ref)
+        T_w = 0.5 * (T[:-1, :] + T[1:, :])
+        buoyancy = np.zeros_like(w)
+        buoyancy[1:-1, :] = g * alpha * (T_w - T_ref)
 
-        # Convection terms
-        conv_u = u * operators.d_dx(u) + w * operators.d_dz(u)
-        conv_w = u * operators.d_dx(w) + w * operators.d_dz(w)
+        du_dx = operators.d_dx(u)
+        du_dz = operators.d_dz(u)
+        dw_dx = operators.d_dx(w)
+        dw_dz = operators.d_dz(w)
 
-        # Viscous terms
-        visc_u = nu * operators.laplacian(u)
-        visc_w = nu * operators.laplacian(w)
+        w_on_u = np.zeros_like(u)
+        w_on_u[:, 1:-1] = 0.25 * (
+            w[:-1, :-1] + w[1:, :-1] + w[:-1, 1:] + w[1:, 1:]
+        )
+        u_on_w = np.zeros_like(w)
+        u_on_w[1:-1, :] = 0.25 * (
+            u[:-1, :-1] + u[:-1, 1:] + u[1:, :-1] + u[1:, 1:]
+        )
 
-        # Temperature terms
-        temp_conv = u * operators.d_dx(T) + w * operators.d_dz(T)
+        conv_u = u * du_dx + w_on_u * du_dz
+        conv_w = u_on_w * dw_dx + w * dw_dz
+
+        visc_u = nu * (operators.d2_dx2(u) + operators.d2_dz2(u))
+        visc_w = nu * (operators.d2_dx2(w) + operators.d2_dz2(w))
+
+        temp_conv = operators.advection_u(u, w, T)
         temp_diff = kappa * operators.laplacian(T)
 
-        # Momentum equations (without pressure)
         du_dt_star = -conv_u + visc_u
-        dw_dt_star = -conv_w + visc_w + buoyancy  # KEY: buoyancy drives motion
+        dw_dt_star = -conv_w + visc_w + buoyancy
 
-        # Predictor step
         u_star = u + dt * du_dt_star
         w_star = w + dt * dw_dt_star
 
-        # Apply velocity BC to predictor
-        u_star[0, :] = u_star[-1, :] = u_star[:, 0] = u_star[:, -1] = 0
-        w_star[0, :] = w_star[-1, :] = w_star[:, 0] = w_star[:, -1] = 0
+        u_star[0, :] = u_star[-1, :] = 0
+        u_star[:, 0] = u_star[:, -1] = 0
+        w_star[0, :] = w_star[-1, :] = 0
+        w_star[:, 0] = w_star[:, -1] = 0
 
-        # Pressure projection
-        div_u_star = operators.d_dx(u_star) + operators.d_dz(w_star)
+        div_u_star = operators.divergence(u_star, w_star)
         phi = solve_poisson_simple(div_u_star / dt)
+        dphi_dx, dphi_dz = operators.gradient(phi)
 
-        # Pressure gradient
-        dphi_dx = operators.d_dx(phi)
-        dphi_dz = operators.d_dz(phi)
-
-        # Corrector step
         u_new = u_star - dt * dphi_dx
         w_new = w_star - dt * dphi_dz
 
-        # Temperature update
         T_new = T + dt * (-temp_conv + temp_diff)
 
-        # Update variables
-        u = u_new.copy()
-        w = w_new.copy()
-        T = T_new.copy()
-
-        # Apply boundary conditions
+        u, w, T = u_new.copy(), w_new.copy(), T_new.copy()
         apply_bc(u, w, T)
 
-        # Diagnostics every 100 steps
         if (step + 1) % 100 == 0:
             Nu_current = compute_Nu(T)
-            max_vel = np.sqrt(np.max(u ** 2 + w ** 2))
-            max_div = np.max(np.abs(operators.d_dx(u) + operators.d_dz(w)))
-
+            u_p, w_p = operators.interpolate_to_pressure_points(u, w)
+            max_vel = np.sqrt(np.max(u_p ** 2 + w_p ** 2))
+            max_div = np.max(np.abs(operators.divergence(u, w)))
             Nu_history.append(Nu_current)
             max_vel_history.append(max_vel)
-
             print(f"  Step {step + 1:4d}: Nu = {Nu_current:.4f}, max_vel = {max_vel:.4f}, max_div = {max_div:.1e}")
-
-            # Check for instability
             if not np.isfinite(Nu_current) or max_vel > 50:
                 print("  ❌ Instability detected!")
                 break
@@ -377,9 +351,7 @@ def test_simple_rb_collocated_fixed():
     print(f"  Nu = {Nu_final:.4f}")
     print(f"  Max velocity = {max_vel_final:.4f}")
 
-    # Assess result
     convection_detected = max_vel_final > 0.01 and Nu_final > 1.1
-
     if Ra_target > 1708:
         expected = f"Nu > 1 and velocity > 0 (Ra = {Ra_target} > 1708)"
         success = convection_detected
@@ -391,49 +363,42 @@ def test_simple_rb_collocated_fixed():
     print(f"Convection detected: {'✅' if convection_detected else '❌'}")
     print(f"Overall result: {'✅ SUCCESS' if success else '❌ FAILED'}")
 
-    # Enhanced visualization
     fig, axes = plt.subplots(2, 2, figsize=(12, 8))
-
-    # Temperature field
     X, Z = np.meshgrid(x_p, z_p)
+
     ax = axes[0, 0]
     im = ax.contourf(X, Z, T, levels=20, cmap='RdBu_r')
     ax.set_title(f'Temperature (Nu = {Nu_final:.3f})')
     ax.set_aspect('equal')
     plt.colorbar(im, ax=ax)
 
-    # Velocity field
     ax = axes[0, 1]
+    u_p, w_p = operators.interpolate_to_pressure_points(u, w)
+    magnitude = np.sqrt(u_p ** 2 + w_p ** 2)
     skip = max(1, grid.nx // 8)
-    magnitude = np.sqrt(u ** 2 + w ** 2)
     im2 = ax.contourf(X, Z, magnitude, levels=10, cmap='viridis')
     if np.max(magnitude) > 0:
-        Q = ax.quiver(X[::skip, ::skip], Z[::skip, ::skip],
-                      u[::skip, ::skip], w[::skip, ::skip],
-                      scale=None, alpha=0.8, color='white')
+        ax.quiver(X[::skip, ::skip], Z[::skip, ::skip],
+                  u_p[::skip, ::skip], w_p[::skip, ::skip],
+                  scale=None, alpha=0.8, color='white')
     ax.set_title('Velocity Field')
     ax.set_aspect('equal')
     plt.colorbar(im2, ax=ax)
 
-    # Nu evolution
     ax = axes[1, 0]
     time_points = np.arange(len(Nu_history)) * 100 * dt
     ax.plot(time_points, Nu_history, 'b-', linewidth=2, label='Simulated')
     ax.axhline(y=1.0, color='r', linestyle='--', alpha=0.5, label='Nu = 1 (conduction)')
-
-    # Theoretical estimate
     if Ra_target > 1708:
         Nu_theory = 0.23 * (Ra_target / 1000) ** 0.25
         ax.axhline(y=Nu_theory, color='g', linestyle=':', alpha=0.7,
                    label=f'Theory ≈ {Nu_theory:.2f}')
-
     ax.set_xlabel('Time')
     ax.set_ylabel('Nusselt Number')
     ax.set_title('Nu Evolution')
     ax.legend()
     ax.grid(True)
 
-    # Velocity evolution
     ax = axes[1, 1]
     if max_vel_history:
         ax.semilogy(time_points[1:], max_vel_history, 'r-', linewidth=2)
@@ -457,7 +422,7 @@ if __name__ == "__main__":
 
     # Test 2: Fixed physics test with proper pressure projection
     if staggered_success:
-        physics_success = test_simple_rb_collocated_fixed()
+        physics_success = test_simple_rb_staggered_fixed()
 
         if physics_success:
             print(f"\n🎉 ALL TESTS PASSED! Ready for final project.")


### PR DESCRIPTION
## Summary
- Replace collocated Rayleigh-Bénard test with staggered-grid version `test_simple_rb_staggered_fixed`
- Fix staggered velocity interpolation averaging to resolve shape mismatch errors
- Remove emoji from visualization summary to avoid missing font glyph warnings
- Ensure buoyancy term is defined on the w-velocity grid to prevent broadcasting

## Testing
- `python -m py_compile boussinesq_staggered.py`
- Failed: `MPLBACKEND=Agg python boussinesq_staggered.py` (missing dependency: numpy)
- Failed: `pip install numpy matplotlib` (proxy error)


------
https://chatgpt.com/codex/tasks/task_e_68ab12f1e6d48327bae35934400113d7